### PR TITLE
DNS Rework

### DIFF
--- a/configs/sample.yaml
+++ b/configs/sample.yaml
@@ -28,16 +28,17 @@ dns:
     dhcp: false
     # what provider to use (currently we support GCP DNS)
     provider: google
+    # list of network blocks to look for a free IP in, inclusive (if we aren't using dhcp)
+    network_blocks:
+        - 10.0.0.0/32,10.0.1.255/32
+        - 10.1.1.200/32,10.1.1.250/32
+    # DNS ttl
+    ttl: 300
+    # The zone that will be appended to our container names
+    # ex mycontainer would become mycontainer.dev.example.com
+    zone: dev.example.com
     # provider options
     options:
-        # DNS ttl
-        ttl: 300
-        # The zone that will be appended to our container names
-        # ex mycontainer would become mycontainer.dev.example.com
-        zone: dev.example.com
-        # the CIDR address of the network our containers will live on, we
-        # use this to lookup free addresses
-        network: 192.168.2.0/24
         # Path to our GCP service account credentials file for adding and removing entries
         gcp_creds_file: /path/to/creds/service_account.json
         # our GCP project name

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,9 +21,12 @@ type LXDhost struct {
 
 // DNS settings, or are we using DHCP or a 3rd party provider
 type DNS struct {
-	DHCP     bool              `yaml:"dhcp"`     // Are we using DHCP on our network, if true we skip any provider settings
-	Provider string            `yaml:"provider"` // Provider name, current supported: google
-	Options  map[string]string `yaml:"options"`  // Providers options documented at the top of a provider implementation
+	DHCP          bool              `yaml:"dhcp"`           // Are we using DHCP on our network, if true we skip any provider settings
+	Provider      string            `yaml:"provider"`       // Provider name, current supported: google
+	NetworkBlocks []string          `yaml:"network_blocks"` // List of blocks that we can use for IPs, if not defined we can use any IP in the network
+	TTL           int               `yaml:"ttl"`            // Default TTL of DNS entries
+	Zone          string            `yaml:"zone"`           // DNS zone
+	Options       map[string]string `yaml:"options"`        // Providers options documented at the top of a provider implementation
 }
 
 // FileOrCommand is for bootstrapping or other setup, used as an array of sequential "things to do"

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -2,7 +2,11 @@
 package dns
 
 import (
+	"errors"
+	"fmt"
 	"github.com/neophenix/lxdepot/internal/config"
+	"net"
+	"strings"
 )
 
 // RecordList is a simple look at DNS records used as a common return for our interface
@@ -15,17 +19,77 @@ type RecordList struct {
 // support.  I don't like that I coded the record type in the name, but until I decide
 // I need IPv6, etc its good enough
 type DNS interface {
-	GetARecord(name string, network string) (string, error) // returns a string representation of an IPv4 address
-	RemoveARecord(name string) error                        // removes the record from our 3rd party
-	ListARecords() ([]RecordList, error)                    // returns a list of all the A records
+	GetARecord(name string, networkBlocks []string) (string, error) // returns a string representation of an IPv4 address
+	RemoveARecord(name string) error                                // removes the record from our 3rd party
+	ListARecords() ([]RecordList, error)                            // returns a list of all the A records
 }
+
+// DNSOptions holds the various options from the main config we might want to use, this does
+// mean these values are in multiple places, which is odd but they dont' change execpt on restart (today)
+var DNSOptions config.DNS
 
 // New should just hand back the appropriate interface for our config settings,
 // returning from the correct "New" function for our integration
 func New(conf *config.Config) DNS {
+	DNSOptions = conf.DNS
+
 	if conf.DNS.Provider == "google" {
-		return NewGoogleDNS(conf.DNS.Options["gcp_creds_file"], conf.DNS.Options["gcp_project_name"], conf.DNS.Options["gcp_zone_name"], conf.DNS.Options)
+		return NewGoogleDNS(conf.DNS.Options["gcp_creds_file"], conf.DNS.Options["gcp_project_name"], conf.DNS.Options["gcp_zone_name"])
 	}
 
 	return nil
+}
+
+// findFreeARecord takes a populated list of octets 2->4 and a list of network blocks, looks through the list
+// to find an entry != 0 indicating that IP is free and returns it.  Blocks are used in order and we skip
+// 0 and 255 for octet4
+func findFreeARecord(list *[256][256][256]int, networkBlocks []string) (string, error) {
+	for _, block := range networkBlocks {
+		ips := strings.Split(block, ",")
+		_, startnet, err := net.ParseCIDR(strings.TrimSpace(ips[0]))
+		if err != nil {
+			return "", err
+		}
+		_, endnet, err := net.ParseCIDR(strings.TrimSpace(ips[1]))
+		if err != nil {
+			return "", err
+		}
+
+		octet1 := int(startnet.IP[0])
+		octet2 := int(startnet.IP[1])
+		octet3 := int(startnet.IP[2])
+		octet4 := int(startnet.IP[3])
+
+		// don't hand back a .0
+		if octet4 == 0 {
+			octet4 = 1
+		}
+
+		for ; octet2 <= 255; octet2++ {
+			if octet2 > int(endnet.IP[1]) {
+				break
+			}
+
+			for ; octet3 <= 255; octet3++ {
+				if octet3 > int(endnet.IP[2]) {
+					break
+				}
+
+				// don't hand out a .255 so only look up to .254
+				for ; octet4 <= 254; octet4++ {
+					if octet4 > int(endnet.IP[3]) {
+						break
+					}
+
+					if list[octet2][octet3][octet4] == 0 {
+						return fmt.Sprintf("%v.%v.%v.%v", octet1, octet2, octet3, octet4), nil
+					}
+				}
+				octet4 = 1
+			}
+			octet3 = 0
+		}
+	}
+
+	return "", errors.New("Could not find a free A record")
 }

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -1,0 +1,57 @@
+package dns
+
+import "testing"
+
+func TestFindFreeARecord(t *testing.T) {
+	var list [256][256][256]int
+
+	// Test 1, make sure we can find a free IP in a simple case where 0 -> 49 are used
+	for i := 0; i < 50; i++ {
+		list[0][0][i] = 1
+	}
+	ip, err := findFreeARecord(&list, []string{"10.0.0.2/32,10.0.0.100/32"})
+	if err != nil {
+		t.FailNow()
+	}
+	if ip != "10.0.0.50" {
+		t.Errorf("T1: Expected 10.0.0.50 got %v", ip)
+	}
+
+	// Test 2, could not find a record
+	ip, err = findFreeARecord(&list, []string{"10.0.0.2/32, 10.0.0.40/32"})
+	if ip != "" {
+		t.Errorf("T2: Expected no ip got %v", ip)
+	}
+
+	// Test 3, find an IP in a second block passed when the first is used up
+	ip, err = findFreeARecord(&list, []string{"10.0.0.2/32,10.0.0.25/32", "10.0.0.40/32, 10.0.0.100/32"})
+	if err != nil {
+		t.FailNow()
+	}
+	if ip != "10.0.0.50" {
+		t.Errorf("T3: Expected 10.0.0.50 got %v", ip)
+	}
+
+	// Test 4, find an IP after exhausting the 3rd octet
+	for i := 0; i < 256; i++ {
+		list[0][0][i] = 1
+	}
+	ip, err = findFreeARecord(&list, []string{"10.0.0.2/32,10.0.1.255/32"})
+	if err != nil {
+		t.FailNow()
+	}
+	if ip != "10.0.1.1" {
+		t.Errorf("T4: Expected 10.0.1.1 got %v", ip)
+	}
+
+	// Test 5, find a record where the end block's 4th octet is smaller than the start block's
+	// basically the same as above but I figured I might have got this wrong and they can fail in
+	// different ways
+	ip, err = findFreeARecord(&list, []string{"10.0.0.100/32,10.0.1.40/32"})
+	if err != nil {
+		t.FailNow()
+	}
+	if ip != "10.0.1.1" {
+		t.Errorf("T4: Expected 10.0.1.1 got %v", ip)
+	}
+}

--- a/internal/handlers/ws/handler_createcontainer.go
+++ b/internal/handlers/ws/handler_createcontainer.go
@@ -53,7 +53,7 @@ func CreateContainerHandler(conn *websocket.Conn, mt int, msg IncomingMessage) {
 			data, _ := json.Marshal(OutgoingMessage{ID: id, Message: "failed to create DNS object for provider: " + Conf.DNS.Provider, Success: false})
 			conn.WriteMessage(mt, data)
 		} else {
-			ip, err := d.GetARecord(msg.Data["name"], Conf.DNS.Options["network"])
+			ip, err := d.GetARecord(msg.Data["name"], Conf.DNS.NetworkBlocks)
 			if err != nil {
 				data, _ := json.Marshal(OutgoingMessage{ID: id, Message: "failed: " + err.Error(), Success: false})
 				conn.WriteMessage(mt, data)


### PR DESCRIPTION
In prep for adding another provider (AWS Route 53)

 * Break out the function for finding a free IP in a list to the
   main DNS file so both GCP + AWS can use it

 * Change from just giving a network to look for an IP on to blocks
   that go from a /32 -> /32 so you can still look over an entire
   network, or parts of it, or over several, more control there

 * Pull more global DNS options into the main DNS "config" section
   and limit the Options section to provider specific items

 * Store the DNS options in the DNS package to make them more
   accessible there

 * Fix example config

 * Added test for finding free IP